### PR TITLE
Add unit tests for com.github.neatlife.jframework.fundation.util.IpUtil and HexUtil

### DIFF
--- a/jframework-test/pom.xml
+++ b/jframework-test/pom.xml
@@ -47,6 +47,20 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>2.0.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>2.0.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/jframework-test/src/test/java/com/github/neatlife/jframework/test/util/HexUtilTest.java
+++ b/jframework-test/src/test/java/com/github/neatlife/jframework/test/util/HexUtilTest.java
@@ -1,0 +1,30 @@
+package com.github.neatlife.jframework.test.util;
+
+import com.github.neatlife.jframework.fundation.util.HexUtil;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class HexUtilTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testHex2Bytes() throws Exception {
+        Assert.assertArrayEquals(new byte[]{-81, 27}, HexUtil.hex2Bytes("AF1B"));
+
+        thrown.expect(Exception.class);
+        HexUtil.hex2Bytes("AF1");
+    }
+
+    @Test
+    public void testBytes2Hex() {
+        Assert.assertEquals("af1b", HexUtil.bytes2Hex(new byte[]{-81, 27}));
+        Assert.assertEquals("af1b",
+                HexUtil.bytes2Hex(new byte[]{-81, 27}, true));
+        Assert.assertEquals("AF1B",
+                HexUtil.bytes2Hex(new byte[]{-81, 27}, false));
+    }
+}

--- a/jframework-test/src/test/java/com/github/neatlife/jframework/test/util/IpUtilTest.java
+++ b/jframework-test/src/test/java/com/github/neatlife/jframework/test/util/IpUtilTest.java
@@ -1,0 +1,104 @@
+package com.github.neatlife.jframework.test.util;
+
+import com.github.neatlife.jframework.fundation.util.IpUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.powermock.api.mockito.PowerMockito;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class IpUtilTest {
+
+    @Test
+    public void testGetIpAddr1() {
+        HttpServletRequest httpServletRequest =
+                PowerMockito.mock(HttpServletRequest.class);
+        PowerMockito.when(httpServletRequest.getHeader("x-forwarded-for"))
+                .thenReturn("0:0:0:0:0:0:0:1");
+
+        Assert.assertEquals("127.0.0.1", IpUtil.getIpAddr(httpServletRequest));
+    }
+
+    @Test
+    public void testGetIpAddr2() {
+        HttpServletRequest httpServletRequest =
+                PowerMockito.mock(HttpServletRequest.class);
+        PowerMockito.when(httpServletRequest.getHeader("Proxy-Client-IP"))
+                .thenReturn("0:0:0:0:0:0:0:1");
+
+        Assert.assertEquals("127.0.0.1", IpUtil.getIpAddr(httpServletRequest));
+    }
+
+    @Test
+    public void testGetIpAddr3() {
+        HttpServletRequest httpServletRequest =
+                PowerMockito.mock(HttpServletRequest.class);
+        PowerMockito.when(httpServletRequest.getHeader("X-Forwarded-For"))
+                .thenReturn("0:0:0:0:0:0:0:1");
+
+        Assert.assertEquals("127.0.0.1", IpUtil.getIpAddr(httpServletRequest));
+    }
+
+    @Test
+    public void testGetIpAddr4() {
+        HttpServletRequest httpServletRequest =
+                PowerMockito.mock(HttpServletRequest.class);
+        PowerMockito.when(httpServletRequest.getHeader("WL-Proxy-Client-IP"))
+                .thenReturn("0:0:0:0:0:0:0:1");
+
+        Assert.assertEquals("127.0.0.1", IpUtil.getIpAddr(httpServletRequest));
+    }
+
+    @Test
+    public void testGetIpAddr5() {
+        HttpServletRequest httpServletRequest =
+                PowerMockito.mock(HttpServletRequest.class);
+        PowerMockito.when(httpServletRequest.getHeader("X-Real-IP"))
+                .thenReturn("0:0:0:0:0:0:0:1");
+
+        Assert.assertEquals("127.0.0.1", IpUtil.getIpAddr(httpServletRequest));
+    }
+
+    @Test
+    public void testGetIpAddr6() {
+        HttpServletRequest httpServletRequest =
+                PowerMockito.mock(HttpServletRequest.class);
+        PowerMockito.when(httpServletRequest.getRemoteAddr())
+                .thenReturn("10.0.0.1");
+
+        Assert.assertEquals("10.0.0.1", IpUtil.getIpAddr(httpServletRequest));
+    }
+
+    @Test
+    public void testInternalIp() {
+        Assert.assertTrue(IpUtil.internalIp("10.0.0.1"));
+        Assert.assertTrue(IpUtil.internalIp("127.0.0.1"));
+        Assert.assertTrue(IpUtil.internalIp("172.17.0.1"));
+        Assert.assertTrue(IpUtil.internalIp("192.168.1.1"));
+
+        Assert.assertFalse(IpUtil.internalIp("172.0.0.1"));
+        Assert.assertFalse(IpUtil.internalIp("224.0.0.1"));
+        Assert.assertFalse(IpUtil.internalIp("240.0.0.1"));
+    }
+
+    @Test
+    public void testIpv4ToByte() {
+        Assert.assertArrayEquals(new byte[0], IpUtil.ipv4ToByte("foo"));
+        Assert.assertArrayEquals(new byte[0], IpUtil.ipv4ToByte(""));
+        Assert.assertArrayEquals(new byte[0], IpUtil.ipv4ToByte("-10"));
+        Assert.assertArrayEquals(new byte[0], IpUtil.ipv4ToByte("-10.1"));
+        Assert.assertArrayEquals(new byte[0], IpUtil.ipv4ToByte("10.-1"));
+        Assert.assertArrayEquals(new byte[0], IpUtil.ipv4ToByte("-10.1.1"));
+        Assert.assertArrayEquals(new byte[0], IpUtil.ipv4ToByte("10.1.-1"));
+        Assert.assertArrayEquals(new byte[0], IpUtil.ipv4ToByte("-10.1.1.1"));
+        Assert.assertArrayEquals(new byte[0], IpUtil.ipv4ToByte("10.1.1.1.1"));
+        Assert.assertArrayEquals(new byte[]{0, 0, 0, 10},
+                IpUtil.ipv4ToByte("10"));
+        Assert.assertArrayEquals(new byte[]{10, 0, 0, 1},
+                IpUtil.ipv4ToByte("10.1"));
+        Assert.assertArrayEquals(new byte[]{10, 1, 0, 1},
+                IpUtil.ipv4ToByte("10.1.1"));
+        Assert.assertArrayEquals(new byte[]{10, 1, 1, 1},
+                IpUtil.ipv4ToByte("10.1.1.1"));
+    }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `com.github.neatlife.jframework.fundation.util.IpUtil` and `HexUtil` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.